### PR TITLE
✨ Return date and datetimes in result objects

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,5 +6,5 @@ what problem(s) it solves.
 
 # Related Material
 
-See Issue https://github.com/freshbooks/api-nodejs-sdk/issues/<number>
+See Issue https://github.com/freshbooks/freshbooks-python-sdk/issues/<number>
 <!-- Please do not reference internal bug trackers as this is a public project -->

--- a/freshbooks/models.py
+++ b/freshbooks/models.py
@@ -1,6 +1,12 @@
 from collections import namedtuple
+from datetime import date, datetime, timezone
 from enum import IntEnum
 from typing import Any, Optional, Union
+
+try:
+    from zoneinfo import ZoneInfo  # type: ignore
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 
 class VisState(IntEnum):
@@ -47,6 +53,31 @@ class Result:
             return Result(field, {field: field_data})
         if isinstance(field_data, list):
             return ListResult(field, field, {field: field_data}, include_pages=False)
+        if isinstance(field_data, str):
+            # Check if the String is a date
+            try:
+                return date.fromisoformat(field_data)
+            except ValueError:
+                pass
+
+            # Check if the String is a datetime
+            try:
+                # This logic pains me, but datetimes in FreshBooks:
+                # - Project-like resources return dates in UTC.
+                #   Most use proper ISO 8601 format, but many omit the UTC time zone
+                #   designator ("Z") at the end (but are still UTC). Python `fromisoformat`
+                #   doesn't like the "Z", so we strip it.
+                # - Accounting resources return dates in "US/Eastern",
+                #   except the client signup date, which is UTC.
+                #   These dates are in the format "yyyy-MM-dd HH:mm:ss",
+                #   so we can distinguish them with the absent "T".
+                parsed_date = datetime.fromisoformat(field_data.rstrip("Z"))
+                if "T" in field_data or (self._name == "client" and field == "signup_date"):
+                    return parsed_date.replace(tzinfo=timezone.utc)
+                return parsed_date.replace(tzinfo=ZoneInfo("US/Eastern")).astimezone(timezone.utc)
+            except ValueError:
+                return field_data
+
         return field_data
 
     @property

--- a/freshbooks/models.py
+++ b/freshbooks/models.py
@@ -6,7 +6,10 @@ from typing import Any, Optional, Union
 try:
     from zoneinfo import ZoneInfo  # type: ignore
 except ImportError:
-    from backports.zoneinfo import ZoneInfo
+    from backports.zoneinfo import ZoneInfo  # type: ignore
+
+from backports.datetime_fromisoformat import MonkeyPatch  # Remove when we drop python 3.6 support
+MonkeyPatch.patch_fromisoformat()
 
 
 class VisState(IntEnum):
@@ -56,7 +59,7 @@ class Result:
         if isinstance(field_data, str):
             # Check if the String is a date
             try:
-                return date.fromisoformat(field_data)
+                return date.fromisoformat(field_data)  # type: ignore
             except ValueError:
                 pass
 
@@ -71,7 +74,7 @@ class Result:
                 #   except the client signup date, which is UTC.
                 #   These dates are in the format "yyyy-MM-dd HH:mm:ss",
                 #   so we can distinguish them with the absent "T".
-                parsed_date = datetime.fromisoformat(field_data.rstrip("Z"))
+                parsed_date = datetime.fromisoformat(field_data.rstrip("Z"))  # type: ignore
                 if "T" in field_data or (self._name == "client" and field == "signup_date"):
                     return parsed_date.replace(tzinfo=timezone.utc)
                 return parsed_date.replace(tzinfo=ZoneInfo("US/Eastern")).astimezone(timezone.utc)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 urllib3>=1.26
 requests
 backports.zoneinfo;python_version<"3.9"
+backports-datetime-fromisoformat

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 urllib3>=1.26
 requests
+backports.zoneinfo;python_version<"3.9"

--- a/tests/fixtures/get_project_response.json
+++ b/tests/fixtures/get_project_response.json
@@ -3,7 +3,7 @@
         "id": 654321,
         "title": "Awesome Project",
         "description": null,
-        "due_date": null,
+        "due_date": "2021-01-02",
         "client_id": null,
         "internal": true,
         "budget": null,

--- a/tests/test_accounting_resource.py
+++ b/tests/test_accounting_resource.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 import httpretty
 import pytest
@@ -28,9 +28,13 @@ class TestAccountingResources:
         client = self.freshBooksClient.clients.get(self.account_id, client_id)
 
         assert str(client) == "Result(client)"
+        assert client.userid == client_id
         assert client.data["organization"] == "American Cyanamid"
         assert client.organization == "American Cyanamid"
-        assert client.userid == client_id
+        assert client.data["updated"] == "2020-11-01 13:11:10"
+        assert client.updated == datetime(
+            year=2020, month=11, day=1, hour=18, minute=11, second=10, tzinfo=timezone.utc
+        )
 
         assert httpretty.last_request().headers["Authorization"] == "Bearer some_token"
         assert httpretty.last_request().headers["Content-Type"] is None

--- a/tests/test_auth_resource.py
+++ b/tests/test_auth_resource.py
@@ -1,8 +1,11 @@
 import json
-import httpretty
+from datetime import datetime, timezone
 
-from freshbooks import Client as FreshBooksClient, FreshBooksError
+import httpretty
+from freshbooks import Client as FreshBooksClient
+from freshbooks import FreshBooksError
 from freshbooks.client import API_BASE_URL
+
 from tests import get_fixture
 
 
@@ -28,6 +31,11 @@ class TestAuthResources:
         assert current_user.full_name == "Simon Kovalic"
         assert current_user.email == "skovalic@cis.com"
         assert current_user.data["email"] == "skovalic@cis.com"
+        assert current_user.confirmed_at == datetime(
+            year=2017, month=5, day=23, hour=5, minute=57, second=24, tzinfo=timezone.utc
+        )
+        assert current_user.data["confirmed_at"] == "2017-05-23T05:57:24Z"
+
         assert len(current_user.business_memberships) == 2
         assert httpretty.last_request().headers["Authorization"] == "Bearer some_token"
 

--- a/tests/test_events_resource.py
+++ b/tests/test_events_resource.py
@@ -1,9 +1,11 @@
 import json
-import httpretty
+from datetime import datetime, timezone
 
+import httpretty
 from freshbooks import Client as FreshBooksClient
-from freshbooks import PaginateBuilder, FilterBuilder, FreshBooksError
+from freshbooks import FilterBuilder, FreshBooksError, PaginateBuilder
 from freshbooks.client import API_BASE_URL, VERSION
+
 from tests import get_fixture
 
 
@@ -28,6 +30,10 @@ class TestEventsResources:
         assert str(callback) == "Result(callback)"
         assert callback.callbackid == 123
         assert callback.data["callbackid"] == 123
+        assert callback.data["updated_at"] == "2017-08-23T11:45:09Z"
+        assert callback.updated_at == datetime(
+            year=2017, month=8, day=23, hour=11, minute=45, second=9, tzinfo=timezone.utc
+        )
 
         assert httpretty.last_request().headers["Authorization"] == "Bearer some_token"
         assert httpretty.last_request().headers["Content-Type"] is None

--- a/tests/test_projects_resource.py
+++ b/tests/test_projects_resource.py
@@ -1,9 +1,11 @@
 import json
-import httpretty
+from datetime import date, datetime, timezone
 
+import httpretty
 from freshbooks import Client as FreshBooksClient
-from freshbooks import PaginateBuilder, FilterBuilder, FreshBooksError
+from freshbooks import FilterBuilder, FreshBooksError, PaginateBuilder
 from freshbooks.client import API_BASE_URL
+
 from tests import get_fixture
 
 
@@ -30,6 +32,12 @@ class TestProjectsResources:
         assert project.title == "Awesome Project"
         assert project.id == project_id
         assert project.vis_state is None, "Projects use active, not vis_state"
+        assert project.data["updated_at"] == "2020-09-13T03:10:13"
+        assert project.updated_at == datetime(
+            year=2020, month=9, day=13, hour=3, minute=10, second=13, tzinfo=timezone.utc
+        )
+        assert project.data["due_date"] == "2021-01-02"
+        assert project.due_date == date(year=2021, month=1, day=2)
 
         for service in project.services:
             assert service.billable is True

--- a/tests/test_timetracking_resource.py
+++ b/tests/test_timetracking_resource.py
@@ -1,8 +1,10 @@
 import json
-import httpretty
+from datetime import datetime, timezone
 
+import httpretty
 from freshbooks import Client as FreshBooksClient
 from freshbooks.client import API_BASE_URL
+
 from tests import get_fixture
 
 
@@ -25,9 +27,14 @@ class TestTimetrackingResources:
         time_entry = self.freshBooksClient.time_entries.get(self.business_id, time_entry_id)
 
         assert str(time_entry) == "Result(time_entry)"
+        assert time_entry.id == time_entry_id
         assert time_entry.data["duration"] == 3600
         assert time_entry.duration == 3600
-        assert time_entry.id == time_entry_id
+        assert time_entry.data["created_at"] == "2020-10-17T01:09:41Z"
+        assert time_entry.created_at == datetime(
+            year=2020, month=10, day=17, hour=1, minute=9, second=41, tzinfo=timezone.utc
+        )
+
         assert httpretty.last_request().headers["Authorization"] == "Bearer some_token"
         assert httpretty.last_request().headers["Content-Type"] is None
 


### PR DESCRIPTION
# Purpose

Transforms date strings into proper date and datetime objects for ease of use.

datetime objects are zone-aware normalized to UTC even in cases where the API returns EST (accounting endpoints).

# Related Material

See Issue https://github.com/freshbooks/freshbooks-python-sdk/issues/4
<!-- Please do not reference internal bug trackers as this is a public project -->