### PR TITLE
✨ API version header configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add includes parameter to project-like `get` calls
+- Allow API version header configuration
 
 ## 1.1.0
 

--- a/freshbooks/api/resource.py
+++ b/freshbooks/api/resource.py
@@ -24,6 +24,7 @@ class Resource:
         self.base_url = client_config.base_url
         self.access_token = client_config.access_token
         self.user_agent = client_config.user_agent
+        self.api_version = client_config.api_version
         self.timeout = client_config.timeout
         self.session = self._config_session(client_config.auto_retry)
 
@@ -50,6 +51,8 @@ class Resource:
             "Authorization": f"Bearer {self.access_token}",
             "user-agent": self.user_agent
         }
+        if self.api_version:
+            headers["X-API-VERSION"] = self.api_version
         if has_data and method in [HttpVerbs.POST, HttpVerbs.PUT, HttpVerbs.PATCH]:
             headers["Content-Type"] = "application/json"
         return headers

--- a/freshbooks/client.py
+++ b/freshbooks/client.py
@@ -34,8 +34,8 @@ with open(os.path.join(os.path.dirname(__file__), "VERSION")) as f:
 class Client:
     def __init__(self, client_id: str, client_secret: Optional[str] = None, redirect_uri: Optional[str] = None,
                  access_token: Optional[str] = None, refresh_token: Optional[str] = None,
-                 user_agent: Optional[str] = None, timeout: Optional[int] = DEFAULT_TIMEOUT,
-                 auto_retry: bool = True):
+                 user_agent: Optional[str] = None, api_version: Optional[str] = None,
+                 timeout: Optional[int] = DEFAULT_TIMEOUT, auto_retry: bool = True):
         """
         Create a new API client instance for the given `client_id` and `client_secret`.
         This will allow you to follow the authentication flow to get an `access_token`.
@@ -50,6 +50,7 @@ class Client:
             access_token: (Optional) An already authenticated access token to use
             refresh_token: (Optional) An already authenticated refresh token to use
             user_agent: (Optional) A user-agent string to override the default
+            api_version: (Optional) Version of the API to use eg.'2023-02-20'
             timeout: (Optional) Set the timeout for API calls. Defaults to 30
             auto_retry: If the SDK should retry failed call up to 3 times. Defaults to True.
 
@@ -62,6 +63,7 @@ class Client:
         self.access_token = access_token
         self.refresh_token = refresh_token
         self.access_token_expires_at: Optional[datetime] = None
+        self.api_version = api_version
         self.timeout = timeout
         self.auto_retry = auto_retry
 
@@ -86,7 +88,8 @@ class Client:
             base_url=self.base_url,
             user_agent=self.user_agent,
             auto_retry=self.auto_retry,
-            timeout=self.timeout
+            timeout=self.timeout,
+            api_version=self.api_version
         )
 
     def get_auth_request_url(self, scopes: Optional[List[str]] = None) -> str:

--- a/tests/test_accounting_resource.py
+++ b/tests/test_accounting_resource.py
@@ -42,6 +42,29 @@ class TestAccountingResources:
                 == f"FreshBooks python sdk/{VERSION} client_id some_client")
 
     @httpretty.activate
+    def test_get_client__with_version(self):
+        client_id = 12345
+        url = "{}/accounting/account/{}/users/clients/{}".format(API_BASE_URL, self.account_id, client_id)
+        httpretty.register_uri(
+            httpretty.GET,
+            url,
+            body=json.dumps(get_fixture("get_client_response")),
+            status=200
+        )
+        API_VERSION = "2023-02-20"
+
+        freshBooksClient = FreshBooksClient(
+            client_id="some_client", access_token="some_token", api_version=API_VERSION
+        )
+        client = freshBooksClient.clients.get(self.account_id, client_id)
+
+        assert str(client) == "Result(client)"
+        assert client.userid == client_id
+        assert httpretty.last_request().headers["Authorization"] == "Bearer some_token"
+        assert httpretty.last_request().headers["Content-Type"] is None
+        assert httpretty.last_request().headers["X-API-VERSION"] == API_VERSION
+
+    @httpretty.activate
     def test_get_client__includes(self):
         client_id = 12345
         url = "{}/accounting/account/{}/users/clients/{}?include[]=late_reminders&include[]=last_activity".format(


### PR DESCRIPTION
# Purpose

While not fully documented yet, a client application can override its default API version with a header. For testing purposes it is useful to allow configuring the SDK with a version header.

# Related Material

Closes  #47