### PR TITLE
🧑‍💻 Improved auth error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Improved error messages on authorization failures
+
 ## 1.2.0
 
 - Add includes parameter to project-like `get` calls

--- a/freshbooks/client.py
+++ b/freshbooks/client.py
@@ -152,15 +152,19 @@ class Client:
             code_type: code
         }
         response = requests.post(self.token_url, payload, timeout=self.timeout)
-        content = response.json()
         try:
+            content = response.json()
             self.access_token = content["access_token"]
             self.refresh_token = content["refresh_token"]
             created_at = datetime.utcfromtimestamp(content["created_at"])
             expires_in = timedelta(seconds=content["expires_in"])
             self.access_token_expires_at = created_at + expires_in
         except KeyError:
-            raise FreshBooksError(response.status_code, "Failed to fetch access_token", raw_response=response.text)
+            raise FreshBooksError(
+                response.status_code,
+                content.get("error_description") or "Failed to fetch access_token",
+                raw_response=response.text
+            )
         return SimpleNamespace(
             access_token=self.access_token,
             refresh_token=self.refresh_token,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -71,6 +71,22 @@ class TestClientAuth:
     @httpretty.activate
     def test_get_access_token__failure(self):
         url = "{}/auth/oauth/token".format(API_BASE_URL)
+        httpretty.register_uri(
+            httpretty.POST,
+            url,
+            body=json.dumps(get_fixture("auth_me_response__no_auth")),
+            status=403
+        )
+
+        try:
+            self.freshBooksClient.get_access_token("some_grant")
+        except FreshBooksError as e:
+            assert str(e) == "This action requires authentication to continue."
+            assert e.status_code == 403
+
+    @httpretty.activate
+    def test_get_access_token__unknown_failure(self):
+        url = "{}/auth/oauth/token".format(API_BASE_URL)
         httpretty.register_uri(httpretty.POST, url, status=500)
 
         try:


### PR DESCRIPTION
# Purpose

We currently swallow the auth server's error_description when failing to fetch an access token. Refactor to provide the message when available.

# Related Material

Closes #52
